### PR TITLE
Read calibration information instead of assuming it

### DIFF
--- a/netft_utils/include/netft_rdt_driver.h
+++ b/netft_utils/include/netft_rdt_driver.h
@@ -76,7 +76,14 @@ protected:
   //! Asks NetFT to start streaming data.
   void startStreaming(void);
 
-  enum {RDT_PORT=49152};
+  // Gets the calibration info via synchronous TCP request, and sets
+  // the force_scale_ and torque_scale_ appropriately
+  bool readCalibrationInformation(const std::string & address);
+
+  enum {
+    RDT_PORT=49152,
+    TCP_PORT=49151
+  };
   std::string address_;
 
   boost::asio::io_service io_service_;


### PR DESCRIPTION
This implements this TODO in the code: `TODO : Get/Set Force/Torque scale for device`

It uses the TCP interface provided by the NetFT box to read the calibration information.

@jodle001 I am opening this PR here because I needed this in ROS2. Once merged, I would appreciate merging your great ROS2 work back into https://github.com/UTNuclearRoboticsPublic/netft_utils