### PR TITLE
Rebase after upstream merge for frame ID

### DIFF
--- a/netft_utils/include/netft_rdt_driver.h
+++ b/netft_utils/include/netft_rdt_driver.h
@@ -53,7 +53,7 @@ class NetFTRDTDriver : public rclcpp::Node
 {
 public:
   // Start receiving data from NetFT device
-  explicit NetFTRDTDriver(const std::string &address);
+  explicit NetFTRDTDriver(const std::string &address, const std::string &frame_id = "base_link");
 
   ~NetFTRDTDriver() override;
 
@@ -85,6 +85,7 @@ protected:
     TCP_PORT=49151
   };
   std::string address_;
+  std::string frame_id_;
 
   boost::asio::io_service io_service_;
   boost::asio::ip::udp::socket socket_;

--- a/netft_utils/src/netft_node.cpp
+++ b/netft_utils/src/netft_node.cpp
@@ -58,17 +58,19 @@ int main(int argc, char** argv) {
 
     float pub_rate_hz;
     string address;
+    string frame_id;
 
     po::options_description desc("Options");
     desc.add_options()
         ("--ros-args", "ros arguments")
         ("help", "display help")
         ("rate", po::value<float>(&pub_rate_hz)->default_value(500.0), "set publish rate (in hertz)")
-        ("address", po::value<string>(&address), "IP address of NetFT box");
+        ("address", po::value<string>(&address), "IP address of NetFT box")
+        ("frame_id", po::value<string>(&frame_id)->default_value("base_link"), "frame_id for Wrench msgs");
 
     po::positional_options_description p;
     p.add("address", 1);
-
+    p.add("frame_id", 1);
 
     po::variables_map vm;
     po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
@@ -89,7 +91,7 @@ int main(int argc, char** argv) {
     std_msgs::msg::Bool is_ready;
     std::shared_ptr<netft_rdt_driver::NetFTRDTDriver> netft;
     try {
-        netft = std::make_shared<netft_rdt_driver::NetFTRDTDriver>(address);
+        netft = std::make_shared<netft_rdt_driver::NetFTRDTDriver>(address, frame_id);
         is_ready.data = true;
         netft->ready_pub->publish(is_ready);
     }

--- a/netft_utils/src/netft_rdt_driver.cpp
+++ b/netft_utils/src/netft_rdt_driver.cpp
@@ -258,19 +258,20 @@ namespace netft_rdt_driver {
         }
     }
 
-    NetFTRDTDriver::NetFTRDTDriver(const std::string& address) : Node("netft_rdt_driver"),
-                                                                 address_(address),
-                                                                 socket_(io_service_),
-                                                                 stop_recv_thread_(false),
-                                                                 recv_thread_running_(false),
-                                                                 packet_count_(0),
-                                                                 lost_packets_(0),
-                                                                 out_of_order_count_(0),
-                                                                 seq_counter_(0),
-                                                                 diag_packet_count_(0),
-                                                                 last_diag_pub_time_(rclcpp::Clock().now()),
-                                                                 last_rdt_sequence_(0),
-                                                                 system_status_(0) {
+    NetFTRDTDriver::NetFTRDTDriver(const std::string& address, const std::string &frame_id) : Node("netft_rdt_driver"),
+                                    address_(address),
+                                    frame_id_(frame_id),
+                                    socket_(io_service_),
+                                    stop_recv_thread_(false),
+                                    recv_thread_running_(false),
+                                    packet_count_(0),
+                                    lost_packets_(0),
+                                    out_of_order_count_(0),
+                                    seq_counter_(0),
+                                    diag_packet_count_(0),
+                                    last_diag_pub_time_(rclcpp::Clock().now()),
+                                    last_rdt_sequence_(0),
+                                    system_status_(0) {
         // Construct UDP socket
         const udp::endpoint netft_endpoint(boost::asio::ip::address_v4::from_string(address), RDT_PORT);
         socket_.open(udp::v4());
@@ -427,7 +428,7 @@ namespace netft_rdt_driver {
                     }
                     else {
                         tmp_data.header.stamp = rclcpp::Clock().now();
-                        tmp_data.header.frame_id = "base_link";
+                        tmp_data.header.frame_id = frame_id_;
                         tmp_data.wrench.force.x = static_cast<double>(rdt_record.fx_) * force_scale_;
                         tmp_data.wrench.force.y = static_cast<double>(rdt_record.fy_) * force_scale_;
                         tmp_data.wrench.force.z = static_cast<double>(rdt_record.fz_) * force_scale_;


### PR DESCRIPTION
Implements the change in https://github.com/UTNuclearRoboticsPublic/netft_utils/pull/5, complicated by the package renaming for ROS2.

If you merge this, we can get https://github.com/UTNuclearRoboticsPublic/netft_utils/pull/9 merged over there!